### PR TITLE
2 game view should redirect after all questions have been played

### DIFF
--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/BackendActor/backend-actor.js
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/BackendActor/backend-actor.js
@@ -78,5 +78,15 @@ export default class BackendActor {
     return 10 + Math.floor(Math.sqrt(celerity) / 0.1);
   }
 
+  static async getGameMetadata(gameID){
+    if(gameID){
+      const query = new Parse.Query("Game");
+      const game = await(query.get(gameID));
+
+      return game.attributes;
+    }
+
+  }
+
 }
 

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/CompeteView/CompeteView.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/CompeteView/CompeteView.jsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import './CompeteView.css';
 import Game from '../Game/Game';
+import Results from '../Results/Results';
 import { BrowserRouter,
   Route,
   Routes,
@@ -48,6 +49,7 @@ export default function CompeteView() {
             </div>}>
         </Route>
         <Route path="/:gameID" element={<Game />}></Route>
+        <Route path="/:gameID/results" element={<Results />}></Route>
       </Routes>
       
     </div>
@@ -56,7 +58,6 @@ export default function CompeteView() {
 
 
 function GameListItem(props) {
-  console.log('props: ', props);
   return  (
     <div className='game-list-item'>
       {props.game.attributes.title} <Link to={`/compete/${props.game.id}`}> Enter</Link>

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
@@ -59,8 +59,9 @@ export default function Game(props) {
                         if(questionNumber == gameData.numQuestions){
                           navigate("./results");
                         } else {
-                          setReadingMode('waitforstrt');
+                          
                           setQuestionNumber(questionNumber + 1);
+                          setReadingMode('waitforstrt');
                         }
                       }}
                     >

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
 import QuestionResult from '../QuestionResult/QuestionResult';
 import QuestionSpeaker from '../QuestionSpeaker/QuestionSpeaker';
-import { useParams } from 'react-router-dom';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import BackendActor from '../BackendActor/backend-actor';
 import './Game.css';
 import GameScore from '../GameScore/GameScore';
 
 export default function Game(props) {
   const {gameID} = useParams();
+  const navigate = useNavigate();
 
+  const [gameData, setGameData] = React.useState({});
   const [questionNumber, setQuestionNumber] = React.useState(0);
   const [prevQuestionDetails, setPrevQuestionDetails] = React.useState(null);
   const [cumulativeScore, setCumulativeScore] = React.useState(0);
@@ -27,6 +29,16 @@ export default function Game(props) {
     setPrevQuestionDetails(questionResults);
   };
 
+  React.useEffect(() => {
+    const updateGameData = async () => {
+      const fetchedGameData = await BackendActor.getGameMetadata(gameID);
+      setGameData(fetchedGameData);
+    }
+
+    updateGameData();
+  }, []);
+
+
   return (
     <div className="game">
       <div className="game-header">
@@ -44,8 +56,12 @@ export default function Game(props) {
                       type="button"
                       className="next-question"
                       onClick={() => {
-                        setReadingMode('waitforstrt');
-                        setQuestionNumber(questionNumber + 1);
+                        if(questionNumber == gameData.numQuestions){
+                          navigate("./results");
+                        } else {
+                          setReadingMode('waitforstrt');
+                          setQuestionNumber(questionNumber + 1);
+                        }
                       }}
                     >
                       Next

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import BackendActor from '../BackendActor/backend-actor';
 import './Results.css';
 
+//placeholder results page
 export default function Results(props) {
   const {gameID} = useParams();
 

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { useParams } from 'react-router-dom';
+import BackendActor from '../BackendActor/backend-actor';
+import './Results.css';
+
+export default function Results(props) {
+  const {gameID} = useParams();
+
+  return (
+    <div className='results'>
+      {`Results of game# ${gameID}`}
+    </div>
+  )
+}


### PR DESCRIPTION
We successfully changed the flow of the game view screen so that it redirects to a placeholder result page after all questions have been played. This functionality is demonstrated in the below screencast:

https://www.screencast.com/t/yVmAgnhqwZ

The next step will be to build out the backend code to register question answers and compute results, and then build and style the results page on the frontend. 

In addition, we fixed a question audio desync bug by preventing the player from hitting the "play" button until all question audio has been loaded. 