### PR TITLE
7 add graphic timers to game view

### DIFF
--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
@@ -49,8 +49,6 @@ export default function Game(props) {
       setTimeout(() => {setBuzzTimer(i)}, i*1000);
     }
     setBuzzTimeout(setTimeout(handleAnswerSubmit, timeAfterBuzz*1000));
-
-
   }
 
   React.useEffect(() => {
@@ -140,7 +138,6 @@ export default function Game(props) {
                     <Progress value={buzzTimer} min={0} max={gameConfig.timeAfterBuzz} w={'140%'} hasStripe/>
                     </VStack>
                 )}
-            
           </VStack>
           {prevQuestionDetails && <QuestionResult results={prevQuestionDetails} />}
         </Flex>

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
@@ -6,7 +6,7 @@ import BackendActor from '../BackendActor/backend-actor';
 import { VStack, Heading, Flex, Center, Button, Input, HStack, Progress} from '@chakra-ui/react';
 
 const gameConfig = {
-  timeAfterBuzz: 5
+  timeAfterBuzz: 6
 }
 
 export default function Game(props) {
@@ -18,13 +18,18 @@ export default function Game(props) {
   const [questionNumber, setQuestionNumber] = React.useState(1);
   const [prevQuestionDetails, setPrevQuestionDetails] = React.useState(null);
   const [cumulativeScore, setCumulativeScore] = React.useState(0);
-  const [buzzTimings, setBuzzTimings] = React.useState({ play: 0, buzz: 0, duration: 0 });
+
   const [buzzTimer, setBuzzTimer] = React.useState(0);
+  const [buzzTimeout, setBuzzTimeout] = React.useState();
+
   const [answerInputText, setAnswerInputText] = React.useState('');
+  const [buzzTimings, setBuzzTimings] = React.useState({ play: 0, buzz: 0, duration: 0 });
+
   const [readingMode, setReadingMode] = React.useState('waitforstrt');
   // modes are waitfornxt: wait for next question to be navigated to
   //           readactive: question audio is being read
   //           waitforstrt: wait for question audio to be read
+  //           submitans: used to trigger answer submission
   //           waitforans: wait for user to type answer to question
 
   const processAnswer = async () => {
@@ -34,10 +39,7 @@ export default function Game(props) {
   };
 
   const handleAnswerSubmit = () => {
-
-      processAnswer();
-      setAnswerInputText('');
-      setReadingMode('waitfornxt');
+    setReadingMode("submitans");
   }
 
   const startBuzzTimer = () => {
@@ -46,6 +48,9 @@ export default function Game(props) {
     for(let i = 1; i <= timeAfterBuzz; i++){
       setTimeout(() => {setBuzzTimer(i)}, i*1000);
     }
+    setBuzzTimeout(setTimeout(handleAnswerSubmit, timeAfterBuzz*1000));
+
+
   }
 
   React.useEffect(() => {
@@ -62,6 +67,18 @@ export default function Game(props) {
       document.getElementById('answer-input').focus();
     }
   }, [readingMode]);
+
+  React.useEffect(() => {
+    if(readingMode === "submitans"){
+      if(buzzTimeout){
+        clearTimeout(buzzTimeout);
+        setBuzzTimeout(0);
+      }
+      processAnswer();
+      setAnswerInputText('');
+      setReadingMode('waitfornxt');
+    }
+  }, [readingMode])
 
   return (
     <Center>

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
@@ -3,7 +3,7 @@ import QuestionResult from '../QuestionResult/QuestionResult';
 import QuestionSpeaker from '../QuestionSpeaker/QuestionSpeaker';
 import { Navigate, useNavigate, useParams, useLocation} from 'react-router-dom';
 import BackendActor from '../BackendActor/backend-actor';
-import { VStack, Heading, Flex, Center, Button, Input, HStack, Progress} from '@chakra-ui/react';
+import { VStack, Box, Heading, Flex, Center, Button, Input, HStack, Progress} from '@chakra-ui/react';
 
 const gameConfig = {
   timeAfterBuzz: 6
@@ -90,6 +90,7 @@ export default function Game(props) {
         </VStack>
         <Flex w={'100%'} justify={'space-between'} wrap={'wrap'}>
           <VStack align={'start'} mb={'20'} minW={'40%'}>
+            <Box width={'400px'}></Box>
           {(readingMode === 'waitfornxt') && (
             <Button
               onClick={() => {
@@ -135,7 +136,7 @@ export default function Game(props) {
                         onClick={handleAnswerSubmit} 
                         >Submit</Button>
                     </HStack>
-                    <Progress value={buzzTimer} min={0} max={gameConfig.timeAfterBuzz} w={'140%'} hasStripe/>
+                    <Progress colorScheme={'red'} value={buzzTimer} min={0} max={gameConfig.timeAfterBuzz} w={'400px'} hasStripe/>
                     </VStack>
                 )}
           </VStack>

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
@@ -33,11 +33,11 @@ export default function Game(props) {
     setPrevQuestionDetails(questionResults);
   };
 
-  const handleAnswerSubmit = (event) => {
-    event.preventDefault();
-    processAnswer();
-    setAnswerInputText('');
-    setReadingMode('waitfornxt');
+  const handleAnswerSubmit = () => {
+
+      processAnswer();
+      setAnswerInputText('');
+      setReadingMode('waitfornxt');
   }
 
   const startBuzzTimer = () => {
@@ -101,26 +101,27 @@ export default function Game(props) {
             )}
           {(readingMode === 'waitforans')
                 && (
-                  <form 
-                  id={'answer-form'}
-                  style={{marginLeft: 0}}
-                  autoComplete="off"
-                  onSubmit={handleAnswerSubmit}>
-                    <VStack spacing={'5'} align={'start'}>
+                    <VStack ml={'0'} spacing={'5'} align={'start'}>
                     <HStack ms={'0'}>
                       <Input w={'100%'}
+                        autoComplete={'off'}
                         id='answer-input'
                         placeholder={'answer'}
                         value={answerInputText}
                         onChange={(event) => {
                           setAnswerInputText(event.target.value);
                         }}
-                      />
-                      <Button type="submit">Submit</Button>
+                        onKeyDown={(event) => {
+                          if(event.key === 'Enter'){
+                            handleAnswerSubmit();
+                          }
+                        }}/>
+                      <Button 
+                        onClick={handleAnswerSubmit} 
+                        >Submit</Button>
                     </HStack>
                     <Progress value={buzzTimer} min={0} max={gameConfig.timeAfterBuzz} w={'140%'} hasStripe/>
                     </VStack>
-                  </form>
                 )}
             
           </VStack>

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/QuestionResult/QuestionResult.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/QuestionResult/QuestionResult.jsx
@@ -17,7 +17,7 @@ function pointsFromCelerity(celerity) {
 
 export default function QuestionResult(props) {
   return (
-    <Flex direction={'column'} bg={'gray.300'} px={'5'} py={'5'} align={'start'} shadow={'md'}>
+    <Flex direction={'column'} w={'400px'} bg={'gray.300'} px={'5'} py={'5'} align={'start'} shadow={'md'}>
       <Heading size={'md'} mb={'5'}>
         {'Result for Question #'}
         {props.results.question.attributes.questionNumber}

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/QuestionSpeaker/QuestionSpeaker.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/QuestionSpeaker/QuestionSpeaker.jsx
@@ -30,9 +30,10 @@ export default function QuestionSpeaker(props) {
       { ...props.buzzTimings, duration: audioRef.current.duration, play: Date.now() },
     );
     const duration = audioRef.current.duration;
-      for(let i = 1; i <= 20; i++){
-        setTimeout(() => {setAudioProgressTicks(i)}, i * duration * 50);
-      }
+    for(let i = 1; i <= 20; i++){
+      setTimeout(() => {setAudioProgressTicks(i)}, i * duration * 50);
+    }
+    setTimeout(buzz, duration*1000+500);
     props.setReadingMode('readactive');
   };
 

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/QuestionSpeaker/QuestionSpeaker.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/QuestionSpeaker/QuestionSpeaker.jsx
@@ -8,6 +8,7 @@ import {AiFillSound} from 'react-icons/ai'
 export default function QuestionSpeaker(props) {
   const [isLoading, setIsLoading] = React.useState("loading");
   const [audioProgressTicks, setAudioProgressTicks] = React.useState(0);
+  const [buzzTimeout, setBuzzTimeout] = React.useState();
   
   const audioRef = React.useRef();
 
@@ -33,13 +34,17 @@ export default function QuestionSpeaker(props) {
     for(let i = 1; i <= 20; i++){
       setTimeout(() => {setAudioProgressTicks(i)}, i * duration * 50);
     }
-    setTimeout(buzz, duration*1000+500);
+    setBuzzTimeout(setTimeout(buzz, duration*1000+500));
     props.setReadingMode('readactive');
   };
 
   const buzz = () => {
     audioRef.current.pause();
     audioRef.current.muted = true;
+    if(buzzTimeout){
+      clearTimeout(buzzTimeout);
+      setBuzzTimeout(null);
+    }
     props.setBuzzTimings(
       { ...props.buzzTimings, duration: audioRef.current.duration, buzz: Date.now() },
     );

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/QuestionSpeaker/QuestionSpeaker.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/QuestionSpeaker/QuestionSpeaker.jsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import BackendActor from '../BackendActor/backend-actor';
 
-import { Box, Button, Spinner, Icon, HStack} from '@chakra-ui/react';
+import { Box, Button, Spinner, Icon, HStack, VStack, Progress} from '@chakra-ui/react';
 import {AiFillSound} from 'react-icons/ai'
 
 
 export default function QuestionSpeaker(props) {
-  let [isLoading, setIsLoading] = React.useState("loading");
+  const [isLoading, setIsLoading] = React.useState("loading");
+  const [audioProgressTicks, setAudioProgressTicks] = React.useState(0);
   
   const audioRef = React.useRef();
 
@@ -28,6 +29,10 @@ export default function QuestionSpeaker(props) {
     props.setBuzzTimings(
       { ...props.buzzTimings, duration: audioRef.current.duration, play: Date.now() },
     );
+    const duration = audioRef.current.duration;
+      for(let i = 1; i <= 20; i++){
+        setTimeout(() => {setAudioProgressTicks(i)}, i * duration * 50);
+      }
     props.setReadingMode('readactive');
   };
 
@@ -48,9 +53,13 @@ export default function QuestionSpeaker(props) {
       {(isLoading === "loading") && <Spinner />}
       {(props.readingMode === 'waitforstrt' && isLoading === "ready") && <Button onClick={play}>Play Question Audio</Button>}
       {(props.readingMode === 'readactive' && isLoading === "ready") && 
-        <HStack spacing={'5'}>
-          <Button type="button" colorScheme={'red'} onClick={buzz}>Buzz</Button> 
-          <Icon fontSize={'64'} as={AiFillSound}></Icon></HStack>}
+        <VStack align={'start'}>
+          <HStack spacing={'5'}>
+            <Button type="button" colorScheme={'red'} onClick={buzz}>Buzz</Button> 
+            <Icon fontSize={'64'} as={AiFillSound}></Icon>
+          </HStack>
+          <Progress w={'400px'} min={0} max={20} value={audioProgressTicks} hasStripe/>
+        </VStack>}
     </Box>
   );
 }

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/QuestionSpeaker/QuestionSpeaker.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/QuestionSpeaker/QuestionSpeaker.jsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import BackendActor from '../BackendActor/backend-actor';
 
-import { Box, Button, Spinner} from '@chakra-ui/react';
+import { Box, Button, Spinner, Icon, HStack} from '@chakra-ui/react';
+import {AiFillSound} from 'react-icons/ai'
 
 
 export default function QuestionSpeaker(props) {
@@ -38,6 +39,7 @@ export default function QuestionSpeaker(props) {
     );
 
     props.setReadingMode('waitforans');
+    props.startBuzzTimer();
   };
 
 
@@ -45,7 +47,10 @@ export default function QuestionSpeaker(props) {
     <Box>
       {(isLoading === "loading") && <Spinner />}
       {(props.readingMode === 'waitforstrt' && isLoading === "ready") && <Button onClick={play}>Play Question Audio</Button>}
-      {(props.readingMode === 'readactive' && isLoading === "ready") && <Button type="button" colorScheme={'red'} onClick={buzz}>Buzz</Button>}
+      {(props.readingMode === 'readactive' && isLoading === "ready") && 
+        <HStack spacing={'5'}>
+          <Button type="button" colorScheme={'red'} onClick={buzz}>Buzz</Button> 
+          <Icon fontSize={'64'} as={AiFillSound}></Icon></HStack>}
     </Box>
   );
 }


### PR DESCRIPTION
We successfully added timers to gameplay to track both: the progress of the question audio being read, and the time the player has to type their answer after they buzz. The timers are displayed with progress bars on screen, and when they run out, the proper automatic action is performed. 

Demo: https://www.screencast.com/t/7g9MEO6c0xP