### PR TITLE
31 add loading spinners wherever data is fetched from backend + 30 created games list, games played list

### DIFF
--- a/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/gameData.js
+++ b/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/gameData.js
@@ -45,3 +45,17 @@ Parse.Cloud.define("fetchAvailableGames", async (request) => {
                              return response;}));
   return gamesData;
 });
+
+// fetch data of all games created by user
+Parse.Cloud.define("fetchCreatedGames", async (request) => {
+  const query = new Parse.Query("Game");
+  query.equalTo("author", request.user);
+  const games = await query.find();
+  
+  
+  const gamesData = await Promise.all(
+                           games.map(async (e) => {
+                             const response = await fetchGameData(e.id);
+                             return response;}));
+  return gamesData;
+})

--- a/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/gameData.js
+++ b/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/gameData.js
@@ -59,3 +59,21 @@ Parse.Cloud.define("fetchCreatedGames", async (request) => {
                              return response;}));
   return gamesData;
 })
+
+// fetch data of all games played by user 
+Parse.Cloud.define("fetchPlayedGames", async (request) => {
+  const query = new Parse.Query("Game");
+  
+  const games = await query.filter(async (game) => {
+    const players = await game.get("players");
+    return (players.indexOf(request.user.id) !== -1);
+    
+  });
+  const gamesData = await Promise.all(
+                           games.map(async (e) => {
+                             const response = await fetchGameData(e.id);
+                             return response;}));
+  return gamesData;
+  
+  
+})

--- a/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/gatekeepEntry.js
+++ b/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/gatekeepEntry.js
@@ -39,6 +39,14 @@ Parse.Cloud.define("registerGameEntry", async (request) => {
   
   await newGameResult.save(null, { useMasterKey: true });
   
+  let gamePlayers = await gameRef.get("players");
+  
+  gamePlayers = gamePlayers.concat([request.user.id]);
+  gamePlayers = gamePlayers.filter((elem, idx) => gamePlayers.indexOf(elem) === idx);
+  gameRef.set("players", gamePlayers);
+  
+  await gameRef.save(null, { useMasterKey: true }); 
+  
   return {message:"successful entry", resultKey:newGameResult.id};
   
 });

--- a/buzzmoon-frontend/buzzmoon-vite/index.html
+++ b/buzzmoon-frontend/buzzmoon-vite/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite App</title>
+    <title>BuzzMoon</title>
     <script src="https://kit.fontawesome.com/5cd2be0779.js" crossorigin="anonymous"></script>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"/>    

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/BackendActor/backend-actor.js
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/BackendActor/backend-actor.js
@@ -66,6 +66,12 @@ export default class BackendActor {
     return data.audio._url;
   }
 
+  // fetches a list of played games
+  static async getPlayedGames() {
+    const responses = await Parse.Cloud.run("fetchPlayedGames", {});
+    return responses;
+  }
+
   // fetches a list of created games
   static async getCreatedGames() {
     const responses = await Parse.Cloud.run("fetchCreatedGames", {});

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/BackendActor/backend-actor.js
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/BackendActor/backend-actor.js
@@ -66,6 +66,12 @@ export default class BackendActor {
     return data.audio._url;
   }
 
+  // fetches a list of created games
+  static async getCreatedGames() {
+    const responses = await Parse.Cloud.run("fetchCreatedGames", {});
+    return responses;
+  }
+
   // fetches a list of available games
   static async getGames() {
     //const query = new Parse.Query('Game');

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/CompeteView/CompeteView.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/CompeteView/CompeteView.jsx
@@ -8,15 +8,18 @@ import { BrowserRouter,
 import BackendActor from '../BackendActor/backend-actor';
 import GameSplashPage from '../GameSplashPage/GameSplashPage';
 
-import { VStack, Heading, Flex, Center, Button, Text} from '@chakra-ui/react';
+import { VStack, Heading, Flex, Center, Button, Text, Spinner} from '@chakra-ui/react';
 
 export default function CompeteView() {
-  let [games, setGames] = React.useState([]);
+  const [availableGames, setAvailableGames] = React.useState();
+  const [gamesPlayed, setGamesPlayed] = React.useState();
 
   React.useEffect(() => {
     const fetchGames = async () => {
       const games = await BackendActor.getGames();
-      setGames(games);
+      setAvailableGames(games);
+
+      setGamesPlayed([]); //placeholder
     }
     
     fetchGames();
@@ -29,16 +32,23 @@ export default function CompeteView() {
           element={
             <Center mt={'20'}>
               <Flex w={'60%'} direction={'row'} justify={'space-between'} wrap={'wrap'}>
-                <VStack boxShadow={'xl'} bg={'gray.200'} p={'5'} spacing={'5'} mb={'5'}>
+                <VStack boxShadow={'xl'} bg={'gray.200'} p={'5'} spacing={'5'} mb={'5'} minW={'33%'} minH={'100%'}>
                   <Heading size="md" borderBottom={'2px solid black'}>Available Games</Heading>
                   <VStack spacing={'1px'}>
-                    {games.map((e) => (
-                      <GameListItem key={e.gameID} game={e}/>
-                    ))}
+                    {availableGames ? 
+                      availableGames.map((e) => (
+                        <GameListItem key={e.gameID} game={e}/>
+                      )) : <Spinner />}
                   </VStack>
                 </VStack>
-                <VStack boxShadow={'xl'} bg={'gray.200'} p={'5'} spacing={'5'} align={'start'}>
+                <VStack boxShadow={'xl'} bg={'gray.200'} p={'5'} spacing={'5'} mb={'5'} minW={'33%'} minH={'100%'}>
                   <Heading size="md" borderBottom={'2px solid black'}>Games Played</Heading>
+                  <VStack spacing={'1px'}>
+                    {gamesPlayed ? 
+                      gamesPlayed.map((e) => (
+                        <GameListItem key={e.gameID} game={e}/>
+                      )) : <Spinner />}
+                  </VStack>
                 </VStack>
               </Flex>
             </Center>}>

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/CompeteView/CompeteView.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/CompeteView/CompeteView.jsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Game from '../Game/Game';
+import GameListItem from '../GameListItem/GameListItem';
 import Results from '../Results/Results';
 import { BrowserRouter,
   Route,
@@ -7,6 +8,7 @@ import { BrowserRouter,
   useNavigate} from 'react-router-dom';
 import BackendActor from '../BackendActor/backend-actor';
 import GameSplashPage from '../GameSplashPage/GameSplashPage';
+import GameList from '../GameList/GameList';
 
 import { VStack, Heading, Flex, Center, Button, Text, Spinner} from '@chakra-ui/react';
 
@@ -32,24 +34,8 @@ export default function CompeteView() {
           element={
             <Center mt={'20'}>
               <Flex w={'60%'} direction={'row'} justify={'space-between'} wrap={'wrap'}>
-                <VStack boxShadow={'xl'} bg={'gray.200'} p={'5'} spacing={'5'} mb={'5'} minW={'33%'} minH={'100%'}>
-                  <Heading size="md" borderBottom={'2px solid black'}>Available Games</Heading>
-                  <VStack spacing={'1px'}>
-                    {availableGames ? 
-                      availableGames.map((e) => (
-                        <GameListItem key={e.gameID} game={e}/>
-                      )) : <Spinner />}
-                  </VStack>
-                </VStack>
-                <VStack boxShadow={'xl'} bg={'gray.200'} p={'5'} spacing={'5'} mb={'5'} minW={'33%'} minH={'100%'}>
-                  <Heading size="md" borderBottom={'2px solid black'}>Games Played</Heading>
-                  <VStack spacing={'1px'}>
-                    {gamesPlayed ? 
-                      gamesPlayed.map((e) => (
-                        <GameListItem key={e.gameID} game={e}/>
-                      )) : <Spinner />}
-                  </VStack>
-                </VStack>
+                <GameList heading={"Play Now"} games={availableGames}></GameList>
+                <GameList heading={"Games Played"} games={gamesPlayed}></GameList>
               </Flex>
             </Center>}>
         </Route>
@@ -63,20 +49,4 @@ export default function CompeteView() {
   );
 }
 
-function GameListItem(props) {
-  const navigate = useNavigate();
 
-  return  (
-    <Flex w={'100%'} justify={'space-between'} align={'center'}>
-      <Text mr={'5'}>{props.game.title} </Text>
-      <Button 
-        colorScheme={'gray'}
-        variant={'outline'}
-        onClick={() => {
-        navigate(`/compete/${props.game.gameID}`);
-      }}>
-        Enter
-      </Button>
-    </Flex>
-  )
-}

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/CompeteView/CompeteView.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/CompeteView/CompeteView.jsx
@@ -21,7 +21,8 @@ export default function CompeteView() {
       const games = await BackendActor.getGames();
       setAvailableGames(games);
 
-      setGamesPlayed([]); //placeholder
+      const playedGames = await BackendActor.getPlayedGames();
+      setGamesPlayed(playedGames) //placeholder
     }
     
     fetchGames();

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/CreateGame/CreateGame.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/CreateGame/CreateGame.jsx
@@ -3,7 +3,7 @@ import BackendActor from '../BackendActor/backend-actor';
 import CreateQuestion from '../CreateQuestion/CreateQuestion';
 import { useNavigate } from "react-router-dom";
 
-import { VStack, Text, Heading, Input, Flex, Button, Center, Textarea, Icon} from '@chakra-ui/react';
+import { VStack, Text, Heading, Input, Flex, Button, Center, Textarea, Icon, Spinner} from '@chakra-ui/react';
 import {AiOutlineUpload} from 'react-icons/ai'
 
 
@@ -20,6 +20,7 @@ export default function CreateGame() {
   const [title, setTitle] = React.useState('');
   const [desc, setDesc] = React.useState('');
   const [questions, setQuestions] = React.useState([]);
+  const [isUploading, setIsUploading] = React.useState(false);
 
   const navigate = useNavigate();
 
@@ -91,18 +92,21 @@ export default function CreateGame() {
             Add Question
           </Button>
       </VStack>
-      <Button
-        leftIcon={<Icon fontSize={'24'} as={AiOutlineUpload}></Icon>}
-        size={'lg'}
-        colorScheme={'blue'}
-        onClick={async () => {
-          const message = await BackendActor.uploadGame(BackendActor.prepareGameData(title, desc, questions));
-          if(message === "Success"){
-            navigate("/compete");
-          }
-        }}>
+      {isUploading ? <Spinner /> : 
+        <Button
+          leftIcon={<Icon fontSize={'24'} as={AiOutlineUpload}></Icon>}
+          size={'lg'}
+          colorScheme={'blue'}
+          onClick={async () => {
+            setIsUploading(true);
+            const message = await BackendActor.uploadGame(BackendActor.prepareGameData(title, desc, questions));
+            if(message === "Success"){
+              navigate("/compete");
+            }
+            setIsUploading(false);
+          }}>
         Upload to Server
-      </Button>
+      </Button>}
     </VStack>
     </Center>
   );

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/CreateView/CreateView.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/CreateView/CreateView.jsx
@@ -1,20 +1,32 @@
 import * as React from 'react';
 import { Routes, Route, Link } from 'react-router-dom';
 
-import { VStack, Box, Heading, Flex, Center, Button, Text} from '@chakra-ui/react';
+import { VStack, Box, Heading, Spinner, Center, Button, Text} from '@chakra-ui/react';
+import BackendActor from '../BackendActor/backend-actor';
 
 import CreateGame from '../CreateGame/CreateGame';
+import GameListItem from '../GameListItem/GameListItem';
+import GameList from '../GameList/GameList';
 
 export default  function CreateView(props) {
+  const [availableGames, setAvailableGames] = React.useState();
+
+  React.useEffect(() => {
+    const fetchGames = async () => {
+      const games = await BackendActor.getCreatedGames();
+      setAvailableGames(games);
+    }
+    
+    fetchGames();
+  }, []);
+
   return (
       <Routes>
         <Route path="/" element={
           <Center>
             <Box mt={'10'}>
               <VStack spacing={'8'}>
-                <VStack boxShadow={'xl'} bg={'gray.200'} p={'5'} spacing={'5'} align={'start'}>
-                  <Heading size="md" borderBottom={'2px solid black'}>Your Created Games</Heading>
-                </VStack>
+                <GameList heading={'Created Games'} games={availableGames}></GameList>
                 <Link to="/create/new">
                   <Button leftIcon={<i className="fa-solid fa-plus"></i>} colorScheme={'green'}>
                     Create New

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
@@ -33,6 +33,7 @@ export default function Game(props) {
   //           waitforans: wait for user to type answer to question
 
   const processAnswer = async () => {
+    setPrevQuestionDetails({waiting:true});
     let questionResults = await BackendActor.getQuestionResults(gameID, resultKey, questionNumber, answerInputText, buzzTimings);
     setCumulativeScore(cumulativeScore + questionResults.points);
     setPrevQuestionDetails(questionResults);

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/GameList/GameList.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/GameList/GameList.jsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+import GameListItem from '../GameListItem/GameListItem';
+
+import { VStack, Heading, Spinner} from '@chakra-ui/react';
+
+export default function GameList({heading, games}) {
+  return (
+    <VStack boxShadow={'xl'} bg={'gray.200'} p={'5'} spacing={'5'} mb={'5'} minW={'33%'} minH={'100%'}>
+      <Heading size="md" borderBottom={'2px solid black'}>{heading}</Heading>
+      <VStack spacing={'1px'}>
+        {games ? 
+          games.map((e) => (
+            <GameListItem key={e.gameID} game={e}/>
+          )) : <Spinner />}
+      </VStack>
+    </VStack>
+  )
+}

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/GameListItem/GameListItem.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/GameListItem/GameListItem.jsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import Game from '../Game/Game';
+import Results from '../Results/Results';
+import { BrowserRouter,
+  Route,
+  Routes,
+  useNavigate} from 'react-router-dom';
+import BackendActor from '../BackendActor/backend-actor';
+import GameSplashPage from '../GameSplashPage/GameSplashPage';
+
+import { VStack, Heading, Flex, Center, Button, Text, Spinner} from '@chakra-ui/react';
+
+export default function GameListItem(props) {
+  const navigate = useNavigate();
+
+  return  (
+    <Flex w={'100%'} justify={'space-between'} align={'center'}>
+      <Text mr={'5'}>{props.game.title} </Text>
+      <Button 
+        colorScheme={'gray'}
+        variant={'outline'}
+        onClick={() => {
+        navigate(`/compete/${props.game.gameID}`);
+      }}>
+        Enter
+      </Button>
+    </Flex>
+  )
+}

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/QuestionResult/QuestionResult.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/QuestionResult/QuestionResult.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
 
-import { VStack, Box, Heading, Text, Flex} from '@chakra-ui/react';
+import { Spinner, Box, Heading, Text, Flex} from '@chakra-ui/react';
 
 
 const formatConfig = {
@@ -16,6 +16,10 @@ function pointsFromCelerity(celerity) {
 }
 
 export default function QuestionResult(props) {
+  if(props.results.waiting){
+    return <Spinner />
+  }
+  
   return (
     <Flex direction={'column'} w={'400px'} bg={'gray.300'} px={'5'} py={'5'} align={'start'} shadow={'md'}>
       <Heading size={'md'} mb={'5'}>


### PR DESCRIPTION
We added spinners to the site wherever data is fetched from the backend and is still loading. This makes the user experience of the site a little smoother. In addition, we set up the backend and frontend code for the "created games list" in create view and the "played games list" in compete view. These help the user keep track of their past results and creations, and make it easier to find where they want to go. 

Demo: https://www.screencast.com/t/v6XgRRmExF