### PR TITLE
27 add checks before navigating away from state sensitive views

### DIFF
--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/App/App.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/App/App.jsx
@@ -28,16 +28,6 @@ function App() {
     }
   }, []);
 
-  const handleLogOut = async () => {
-    try {
-      await Parse.User.logOut();
-      setCurrentUser(null);
-    } catch (error) {
-      console.log('error: ', error);
-      
-    }
-  }
-
   if(currentUser == null){
     return (<Auth setCurrentUser={setCurrentUser}/>)
   }else{
@@ -56,7 +46,7 @@ function App() {
     );
   }
 
-  
+
 }
 
 export default App;

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/CompeteView/CompeteView.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/CompeteView/CompeteView.jsx
@@ -40,8 +40,8 @@ export default function CompeteView() {
                 <VStack>
                   <GameList heading={"Play Now"} games={availableGames}></GameList>
                   <GameList heading={"Games Played"} games={gamesPlayed}></GameList>
-                </VStack>:
-                <Flex w={{base:'90%', md:'60%'}} direction={'row'} justify={'space-between'} wrap={'wrap'}>
+                </VStack> :
+                <Flex w={{base:'90%', md:'70%'}} direction={'row'} justify={'space-between'} wrap={'wrap'}>
                 <GameList heading={"Play Now"} games={availableGames}></GameList>
                 <GameList heading={"Games Played"} games={gamesPlayed}></GameList>
               </Flex>}

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/CreateGame/CreateGame.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/CreateGame/CreateGame.jsx
@@ -35,6 +35,13 @@ export default function CreateGame() {
       .sort((a, b) => (a.number < b.number ? -1 : 1)));
   };
 
+  React.useEffect(() => {
+    window.onbeforeunload = (e) => {
+      e.preventDefault();
+      return "";
+    };
+  }, [])
+
   return (
     <Center mb={'10'}>
     <VStack w={{base:"95%", md:'80%'}} mt={{base:'4', md:'20'}} spacing={'10'}>

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/CreateGame/CreateGame.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/CreateGame/CreateGame.jsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { VStack, Text, Heading, Input, Flex, Button, Center, Textarea, Icon, Spinner} from '@chakra-ui/react';
 import {AiOutlineUpload} from 'react-icons/ai'
 
+import {usePrompt} from '../../Hooks/routerBlocks.js'
 
 let uniqueQuestions = 0;
 
@@ -21,6 +22,7 @@ export default function CreateGame() {
   const [desc, setDesc] = React.useState('');
   const [questions, setQuestions] = React.useState([]);
   const [isUploading, setIsUploading] = React.useState(false);
+  const [isNavigationOK, setIsNavigationOK] = React.useState(false);
 
   const navigate = useNavigate();
 
@@ -35,12 +37,7 @@ export default function CreateGame() {
       .sort((a, b) => (a.number < b.number ? -1 : 1)));
   };
 
-  React.useEffect(() => {
-    window.onbeforeunload = (e) => {
-      e.preventDefault();
-      return "";
-    };
-  }, [])
+  usePrompt("If you leave the page, your data will not be saved", !isNavigationOK);
 
   return (
     <Center mb={'10'}>
@@ -107,7 +104,10 @@ export default function CreateGame() {
           onClick={async () => {
             setIsUploading(true);
             const message = await BackendActor.uploadGame(BackendActor.prepareGameData(title, desc, questions));
+
             if(message === "Success"){
+              await setIsNavigationOK(true);
+              await new Promise(r => setTimeout(r, 500));
               navigate("/compete");
             }
             setIsUploading(false);

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
@@ -4,6 +4,7 @@ import QuestionSpeaker from '../QuestionSpeaker/QuestionSpeaker';
 import { Navigate, useNavigate, useParams, useLocation} from 'react-router-dom';
 import BackendActor from '../BackendActor/backend-actor';
 import { VStack, Box, Heading, Flex, Center, Button, Input, HStack, Progress} from '@chakra-ui/react';
+import {usePrompt} from '../../Hooks/routerBlocks.js'
 
 const gameConfig = {
   timeAfterBuzz: 6
@@ -60,10 +61,10 @@ export default function Game(props) {
 
     updateGameData();
 
-    window.onbeforeunload = (e) => {
-      e.preventDefault();
-      return "";
-    };
+    // window.onbeforeunload = (e) => {
+    //   e.preventDefault();
+    //   return "";
+    // };
   }, []);
 
   React.useEffect(() => {
@@ -83,6 +84,9 @@ export default function Game(props) {
       setReadingMode('waitfornxt');
     }
   }, [readingMode])
+
+  usePrompt("If you leave the game now, you won't be able to return",
+    questionNumber !== gameData.numQuestions || readingMode !== "waitfornxt");
 
   return (
     <Center>

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
@@ -59,6 +59,12 @@ export default function Game(props) {
     }
 
     updateGameData();
+
+    window.onbeforeunload = (e) => {
+      console.log("🚀 ~ file: Game.jsx ~ line 64 ~ React.useEffect ~ e", e)
+      e.preventDefault();
+      return "If you leave the page now, you won't be able to return to the game";
+    };
   }, []);
 
   React.useEffect(() => {

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
@@ -60,11 +60,6 @@ export default function Game(props) {
     }
 
     updateGameData();
-
-    // window.onbeforeunload = (e) => {
-    //   e.preventDefault();
-    //   return "";
-    // };
   }, []);
 
   React.useEffect(() => {

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Game/Game.jsx
@@ -61,9 +61,8 @@ export default function Game(props) {
     updateGameData();
 
     window.onbeforeunload = (e) => {
-      console.log("🚀 ~ file: Game.jsx ~ line 64 ~ React.useEffect ~ e", e)
       e.preventDefault();
-      return "If you leave the page now, you won't be able to return to the game";
+      return "";
     };
   }, []);
 

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/GameList/GameList.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/GameList/GameList.jsx
@@ -6,10 +6,10 @@ import { VStack, Heading, Spinner} from '@chakra-ui/react';
 
 export default function GameList({heading, games}) {
   return (
-    <VStack boxShadow={'xl'} bg={'gray.200'} p={'5'} spacing={'5'} mb={'5'} minW={'33%'} minH={'100%'}>
+    <VStack boxShadow={'xl'} bg={'gray.200'} p={'5'} spacing={'5'} mb={'5'} minW={'20%'} minH={'100%'}>
       <Heading size="md" borderBottom={'2px solid black'}>{heading}</Heading>
       <VStack spacing={'1px'}>
-        {games ? 
+        {games ?
           games.map((e) => (
             <GameListItem key={e.gameID} game={e}/>
           )) : <Spinner />}

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Navbar/Navbar.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Navbar/Navbar.jsx
@@ -15,7 +15,6 @@ import {
 } from '@chakra-ui/react';
 
 export default function NavbarBox(props) {
-  const breakPoint = useBreakpointValue(['sm, md']);
 
   return (
     <Center w={'100%'} h={'8rem'} top={"0rem"} right={'0rem'}>
@@ -40,21 +39,19 @@ export default function NavbarBox(props) {
             </Heading>
             </Link>
           </HStack>
+          <IconButton
+            onClick={() => {
+              BackendActor.handleLogOut(props.setCurrentUser);
+              }}
+            _hover={{ backgroundColor: 'transparent' }}
+            icon={
+              <Heading fontSize={'3xl'}>
+              <i className="fa-solid fa-arrow-right-from-bracket"></i>
+              </Heading>}
+            size={'auto'}
+            variant='ghost'>
 
-
-            <IconButton
-              onClick={() => {
-                BackendActor.handleLogOut(props.setCurrentUser);
-                }}
-              _hover={{ backgroundColor: 'transparent' }}
-              icon={
-                <Heading fontSize={'3xl'}>
-                <i className="fa-solid fa-arrow-right-from-bracket"></i>
-                </Heading>}
-              size={'auto'}
-              variant='ghost'>
-
-            </IconButton>
+          </IconButton>
         </Flex>
       </Flex>
     </Center>

--- a/buzzmoon-frontend/buzzmoon-vite/src/Hooks/routerBlocks.js
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Hooks/routerBlocks.js
@@ -1,0 +1,44 @@
+/**
+ * These hooks re-implement the now removed useBlocker and usePrompt hooks in 'react-router-dom'.
+ * Thanks for the idea @piecyk https://github.com/remix-run/react-router/issues/8139#issuecomment-953816315
+ * Source: https://github.com/remix-run/react-router/commit/256cad70d3fd4500b1abcfea66f3ee622fb90874#diff-b60f1a2d4276b2a605c05e19816634111de2e8a4186fe9dd7de8e344b65ed4d3L344-L381
+ */
+ import { useContext, useEffect, useCallback } from 'react';
+ import { UNSAFE_NavigationContext as NavigationContext } from 'react-router-dom';
+
+ export function useBlocker( blocker, when = true ) {
+     const { navigator } = useContext( NavigationContext );
+
+     useEffect( () => {
+         if ( ! when ) return;
+
+         const unblock = navigator.block( ( tx ) => {
+             const autoUnblockingTx = {
+                 ...tx,
+                 retry() {
+                     // Automatically unblock the transition so it can play all the way
+                     // through before retrying it. TODO: Figure out how to re-enable
+                     // this block if the transition is cancelled for some reason.
+                     unblock();
+                     tx.retry();
+                 },
+             };
+
+             blocker( autoUnblockingTx );
+         } );
+
+         return unblock;
+     }, [ navigator, blocker, when ] );
+ }
+
+ export function usePrompt( message, when = true ) {
+     const blocker = useCallback(
+         ( tx ) => {
+             // eslint-disable-next-line no-alert
+             if ( window.confirm( message ) ) tx.retry();
+         },
+         [ message ]
+     );
+
+     useBlocker( blocker, when );
+ }

--- a/buzzmoon-frontend/buzzmoon-vite/src/Hooks/routerBlocks.js
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Hooks/routerBlocks.js
@@ -1,6 +1,8 @@
+/* Taken from https://gist.github.com/rmorse/426ffcc579922a82749934826fa9f743
+    all credit to user rmorse */
+
 /**
  * These hooks re-implement the now removed useBlocker and usePrompt hooks in 'react-router-dom'.
- * Thanks for the idea @piecyk https://github.com/remix-run/react-router/issues/8139#issuecomment-953816315
  * Source: https://github.com/remix-run/react-router/commit/256cad70d3fd4500b1abcfea66f3ee622fb90874#diff-b60f1a2d4276b2a605c05e19816634111de2e8a4186fe9dd7de8e344b65ed4d3L344-L381
  */
  import { useContext, useEffect, useCallback } from 'react';
@@ -17,8 +19,7 @@
                  ...tx,
                  retry() {
                      // Automatically unblock the transition so it can play all the way
-                     // through before retrying it. TODO: Figure out how to re-enable
-                     // this block if the transition is cancelled for some reason.
+                     // through before retrying it.
                      unblock();
                      tx.retry();
                  },


### PR DESCRIPTION
We set up usePrompt hooks to prevent navigation away from state sensitive views by prompting the user with an appropriate message before allowing the navigation to go through. In order to do this, we had to use a hacky implementation of usePrompt that we found on github, because usePrompt is currently not implemented in React Router V6

demo: https://www.screencast.com/t/QJD8mReQPK4i