### PR TITLE
42 set up developer dashboard page in site

### DIFF
--- a/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/devTools.js
+++ b/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/devTools.js
@@ -38,6 +38,13 @@ Parse.Cloud.define("getCompleteSchema", async (request) => {
   return schema;
 }, validateRootCloud);
 
+// this function returns all data for a given class name
+Parse.Cloud.define("getClassData", async (request) => {
+  const query = new Parse.Query(request.params.className);
+  const data = await query.find({useMasterKey: true});
+  return data;
+}, validateRootCloud)
+
 
 // this function checks whether a user has root privileges
 Parse.Cloud.define("validateRoot", async (request) => {

--- a/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/devTools.js
+++ b/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/devTools.js
@@ -1,0 +1,29 @@
+
+ const validateRoot = async (request) => {
+    if(!request.user){
+      return false;
+    }
+
+    const queryRole = new Parse.Query(Parse.Role);
+    queryRole.equalTo("name", "Root");
+
+    const role = await queryRole.first({useMasterKey: true});
+
+    const roleRelation = new Parse.Relation(role, "users");
+    const queryRoots = roleRelation.query();
+    queryRoots.equalTo("objectId", request.user.id);
+    const result = await queryRoots.first({useMasterKey: true});
+
+    if(result){
+      return true;
+    } else{
+      return false;
+    }
+  }
+
+
+  // this function validates that a user has root privileges
+  Parse.Cloud.define("validateRoot", async (request) => {
+    const response = await validateRoot(request);
+    return response;
+  });

--- a/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/devTools.js
+++ b/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/devTools.js
@@ -43,7 +43,15 @@ Parse.Cloud.define("getClassData", async (request) => {
   const query = new Parse.Query(request.params.className);
   const data = await query.find({useMasterKey: true});
   return data;
-}, validateRootCloud)
+}, validateRootCloud);
+
+// this function deletes a given object from the database
+Parse.Cloud.define("deleteObject", async (request) => {
+  const query = new Parse.Query(request.params.cName);
+  const obj = await query.get(request.params.id);
+
+  await obj.destroy({useMasterKey: true});
+}, validateRootCloud);
 
 
 // this function checks whether a user has root privileges

--- a/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/devTools.js
+++ b/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/devTools.js
@@ -1,29 +1,46 @@
 
  const validateRoot = async (request) => {
-    if(!request.user){
-      return false;
-    }
-
-    const queryRole = new Parse.Query(Parse.Role);
-    queryRole.equalTo("name", "Root");
-
-    const role = await queryRole.first({useMasterKey: true});
-
-    const roleRelation = new Parse.Relation(role, "users");
-    const queryRoots = roleRelation.query();
-    queryRoots.equalTo("objectId", request.user.id);
-    const result = await queryRoots.first({useMasterKey: true});
-
-    if(result){
-      return true;
-    } else{
-      return false;
-    }
+  if(!request.user){
+    return false;
   }
 
+  const queryRole = new Parse.Query(Parse.Role);
+  queryRole.equalTo("name", "Root");
 
-  // this function validates that a user has root privileges
-  Parse.Cloud.define("validateRoot", async (request) => {
-    const response = await validateRoot(request);
-    return response;
-  });
+  const role = await queryRole.first({useMasterKey: true});
+
+  const roleRelation = new Parse.Relation(role, "users");
+  const queryRoots = roleRelation.query();
+  queryRoots.equalTo("objectId", request.user.id);
+  const result = await queryRoots.first({useMasterKey: true});
+
+  if(result){
+    return true;
+  } else{
+    return false;
+  }
+}
+
+const validateRootCloud = async (request) => {
+  const good = await validateRoot(request);
+  if(!good){
+    throw "You don't have the permissions to perform this action";
+  }
+
+  return;
+}
+
+// this function returns the schema of the entire database
+Parse.Cloud.define("getCompleteSchema", async (request) => {
+ const schema = await Parse.Schema.all({useMasterKey: true});
+
+
+  return schema;
+}, validateRootCloud);
+
+
+// this function checks whether a user has root privileges
+Parse.Cloud.define("validateRoot", async (request) => {
+  const response = await validateRoot(request);
+  return response;
+});

--- a/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/main.js
+++ b/buzzmoon-backend/back4app-cloud-code/back4app-cloud-code/main.js
@@ -2,3 +2,6 @@
 require("./createGame.js");
 require("./registerAnswer.js");
 require("./gatekeepEntry.js");
+require("./gameResults.js");
+require("./gameData.js");
+require("./devTools.js");

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/App/App.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/App/App.jsx
@@ -13,6 +13,7 @@ import Navbar from '../Navbar/Navbar';
 import Auth from '../Auth/Auth';
 import CreateView from '../CreateView/CreateView';
 import CompeteView from '../CompeteView/CompeteView';
+import DevDashboard from '../DevDashboard/DevDashboard';
 
 Parse.initialize(`nUrzDufzLEaJ3sjzvcvNHvw1hD46jOt4yEipaWHs`, `juaO5lbdY5jTtDXGpzEr2mGtggC0wf2Es11cEruf`);
 Parse.serverURL = 'https://parseapi.back4app.com/';
@@ -34,7 +35,7 @@ function App() {
       setCurrentUser(null);
     } catch (error) {
       console.log('error: ', error);
-      
+
     }
   }
 
@@ -46,6 +47,7 @@ function App() {
         <BrowserRouter basename='/buzzmoon'>
           <Navbar setCurrentUser={setCurrentUser} />
           <Routes>
+            <Route path="/dev/" element={<DevDashboard />}></Route>
             <Route path="/" element={<Navigate to="/compete" />}></Route>
             <Route path="/compete/*"  element={<CompeteView />}></Route>
             <Route path="/create/*"  element={<CreateView />}></Route>
@@ -56,7 +58,7 @@ function App() {
     );
   }
 
-  
+
 }
 
 export default App;

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import * as Parse from 'parse/dist/parse.min.js'
+
+import { Center, Text} from '@chakra-ui/react';
+
+Parse.initialize(`nUrzDufzLEaJ3sjzvcvNHvw1hD46jOt4yEipaWHs`, `juaO5lbdY5jTtDXGpzEr2mGtggC0wf2Es11cEruf`);
+Parse.serverURL = 'https://parseapi.back4app.com/';
+
+export default function DevDashboard() {
+    return (
+        <Center>
+            <Text>
+                Dev
+            </Text>
+        </Center>
+    )
+}

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
@@ -1,13 +1,37 @@
 import * as React from 'react';
-
 import * as Parse from 'parse/dist/parse.min.js'
+import DevTools from '../../devtools/devtools';
 
-import { Center, Text} from '@chakra-ui/react';
+import { Center, Text, Spinner} from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
 
 Parse.initialize(`nUrzDufzLEaJ3sjzvcvNHvw1hD46jOt4yEipaWHs`, `juaO5lbdY5jTtDXGpzEr2mGtggC0wf2Es11cEruf`);
 Parse.serverURL = 'https://parseapi.back4app.com/';
 
 export default function DevDashboard() {
+    const navigate = useNavigate();
+    const [isVisible, setIsVisible] = React.useState(false);
+    const [isLoading, setIsLoading] = React.useState(true);
+
+    React.useEffect(() => {
+        const validatePrivileges = async () => {
+            const isAllowed = await DevTools.validateRoot();
+            if(isAllowed){
+                setIsVisible(true);
+            } else{
+                navigate(-1);
+            }
+        }
+
+        validatePrivileges();
+    }, []);
+
+    if(!isVisible){
+        return <Center>
+            <Spinner />
+        </Center>
+    }
+
     return (
         <Center>
             <Text>

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
@@ -3,7 +3,7 @@ import * as Parse from 'parse/dist/parse.min.js'
 import DevTools from '../../DevTools/DevTools';
 
 import { Center, Heading, Spinner, Select, VStack, Text, HStack, Box, Icon,
-         Table, Thead, Th, Tr, Td, TableContainer, Tbody, Checkbox} from '@chakra-ui/react';
+         Table, Thead, Th, Tr, Td, TableContainer, Tbody, Checkbox, Button} from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 import { BsTrash } from "react-icons/bs";
 
@@ -64,8 +64,11 @@ export default function DevDashboard() {
 }
 
 function DatabaseTable(props) {
+    const navigate = useNavigate();
+
     const [data, setData] = React.useState();
     const [objsToDelete, setObjsToDelete] = React.useState([]);
+    const [fetchTrigger, setFetchTrigger] = React.useState(false);
 
     const addToDelete = (obj) => {
         if(!objsToDelete.includes(obj)){
@@ -77,7 +80,6 @@ function DatabaseTable(props) {
         if(objsToDelete.includes(obj)){
             setObjsToDelete(objsToDelete.filter((elem) => (elem !== obj)));
         }
-
     }
 
     const tableHeaders = Object.keys(props.classSchema.fields);
@@ -89,14 +91,22 @@ function DatabaseTable(props) {
         }
 
         fetchData();
-    }, []);
+    }, [fetchTrigger]);
 
     if(!data){
         return <Spinner/>
     }
 
     return (
-        <Box maxW={'90vw'} overflowX={'auto'}>
+        <VStack align={'start'} maxW={'90vw'} overflowX={'auto'}>
+            {objsToDelete.length > 0 &&
+                <Button colorScheme={'red'} onClick={async () => {
+                    await DevTools.deleteObjList(objsToDelete);
+                    setObjsToDelete([]);
+                    setFetchTrigger(!fetchTrigger);
+                }}>
+                    Delete
+                </Button>}
             <TableContainer>
                 <Table >
                     <Thead>
@@ -111,6 +121,7 @@ function DatabaseTable(props) {
                     <Tbody>
                         {data.map((obj, idx) => (
                                 <TableRow
+                                    key={obj.id}
                                     tableHeaders={tableHeaders}
                                     obj={obj}
                                     idx={idx}
@@ -120,20 +131,21 @@ function DatabaseTable(props) {
                     </Tbody>
                 </Table>
             </TableContainer>
-        </Box>
+        </VStack>
     )
 }
 
 function TableRow(props) {
     let rowValues = new Array(props.tableHeaders.length).fill(null);
-    rowValues[1] = props.obj.id;
+    rowValues[0] = props.obj.id;
     Object.keys(props.obj.attributes).map((key) => {
         const mutIndex = props.tableHeaders.findIndex((elem) => (elem === key));
         rowValues[mutIndex] = props.obj.attributes[key];
     })
 
+
     return (
-        <Tr key={props.idx}>
+        <Tr key={props.obj.id}>
             <Td><Checkbox
                 colorScheme={'red'}
                 onChange={(e) => {

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
@@ -26,7 +26,6 @@ export default function DevDashboard() {
 
             const schema = await DevTools.getCompleteSchema();
             setDatabaseSchema(schema);
-
         }
 
         onMount();
@@ -104,7 +103,6 @@ function DatabaseTable(props) {
 }
 
 function TableRow(props) {
-    console.log("🚀 ~ file: DevDashboard.jsx ~ line 107 ~ TableRow ~ props", props)
     let rowValues = new Array(props.tableHeaders.length).fill(null);
     rowValues[0] = props.obj.id;
     Object.keys(props.obj.attributes).map((key) => {

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as Parse from 'parse/dist/parse.min.js'
 import DevTools from '../../DevTools/DevTools';
 
-import { Center, Text, Spinner} from '@chakra-ui/react';
+import { Center, Heading, Spinner, Select, VStack, Text, HStack, Box, Table, Thead, Th} from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 
 Parse.initialize(`nUrzDufzLEaJ3sjzvcvNHvw1hD46jOt4yEipaWHs`, `juaO5lbdY5jTtDXGpzEr2mGtggC0wf2Es11cEruf`);
@@ -11,8 +11,8 @@ Parse.serverURL = 'https://parseapi.back4app.com/';
 export default function DevDashboard() {
     const navigate = useNavigate();
     const [isVisible, setIsVisible] = React.useState(false);
-    const [databaseSchema, setDatabaseSchema] = React.useState({});
-    console.log("🚀 ~ file: DevDashboard.jsx ~ line 15 ~ DevDashboard ~ databaseSchema", databaseSchema)
+    const [databaseSchema, setDatabaseSchema] = React.useState([]);
+    const [selectedClass, setSelectedClass] = React.useState(undefined);
 
     React.useEffect(() => {
         const onMount = async () => {
@@ -38,10 +38,43 @@ export default function DevDashboard() {
     }
 
     return (
-        <Center>
-            <Text>
-                Dev
-            </Text>
-        </Center>
+        <VStack mt={'20'} mx={'5%'} align={'start'}>
+            <VStack align={'start'}>
+            <Heading>Database</Heading>
+            <HStack>
+                <Text>Class:</Text>
+                <Select
+                    placeholder="Select Class"
+                    value={selectedClass}
+                    onChange={(event) => {setSelectedClass(event.target.value);}}>
+                    {databaseSchema.map((schema) => (
+                        <option value={schema.className}>{schema.className}</option>
+                    ))}
+                </Select>
+            </HStack>
+            {selectedClass ?
+                <DatabaseTable
+                    classSchema={databaseSchema.find((e) => (e.className == selectedClass))}
+                    /> : null}
+            </VStack>
+        </VStack>
+    )
+}
+
+function DatabaseTable(props) {
+    return (
+        <Box maxW={'90vw'} overflowX={'auto'}>
+        <Table >
+            <Thead>
+                {
+                    Object.keys(props.classSchema.fields).map((key) => (
+                        <Th>{key}</Th>
+                    ))
+                }
+
+            </Thead>
+
+        </Table>
+        </Box>
     )
 }

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 import * as Parse from 'parse/dist/parse.min.js'
 import DevTools from '../../DevTools/DevTools';
 
-import { Center, Heading, Spinner, Select, VStack, Text, HStack, Box,
-         Table, Thead, Th, Tr, Td, TableContainer, Tbody} from '@chakra-ui/react';
+import { Center, Heading, Spinner, Select, VStack, Text, HStack, Box, Icon,
+         Table, Thead, Th, Tr, Td, TableContainer, Tbody, Checkbox} from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
+import { BsTrash } from "react-icons/bs";
+
 
 Parse.initialize(`nUrzDufzLEaJ3sjzvcvNHvw1hD46jOt4yEipaWHs`, `juaO5lbdY5jTtDXGpzEr2mGtggC0wf2Es11cEruf`);
 Parse.serverURL = 'https://parseapi.back4app.com/';
@@ -63,6 +65,20 @@ export default function DevDashboard() {
 
 function DatabaseTable(props) {
     const [data, setData] = React.useState();
+    const [objsToDelete, setObjsToDelete] = React.useState([]);
+
+    const addToDelete = (obj) => {
+        if(!objsToDelete.includes(obj)){
+            setObjsToDelete(objsToDelete.concat([obj]));
+        }
+    }
+
+    const removeFromDelete = (obj) => {
+        if(objsToDelete.includes(obj)){
+            setObjsToDelete(objsToDelete.filter((elem) => (elem !== obj)));
+        }
+
+    }
 
     const tableHeaders = Object.keys(props.classSchema.fields);
 
@@ -84,18 +100,24 @@ function DatabaseTable(props) {
             <TableContainer>
                 <Table >
                     <Thead>
-                        <Tr>{
-                           tableHeaders.map((e) => (
-                               <Th key={e}>{e}</Th>
+                        <Tr>
+                            <Th><Icon as={BsTrash}></Icon></Th>
+                            {
+                            tableHeaders.map((e) => (
+                                <Th key={e}>{e}</Th>
                             ))}
                         </Tr>
                     </Thead>
                     <Tbody>
                         {data.map((obj, idx) => (
-                                <TableRow tableHeaders={tableHeaders} obj={obj} idx={idx}></TableRow>
+                                <TableRow
+                                    tableHeaders={tableHeaders}
+                                    obj={obj}
+                                    idx={idx}
+                                    addToDelete={addToDelete}
+                                    removeFromDelete={removeFromDelete}></TableRow>
                             ))}
                     </Tbody>
-
                 </Table>
             </TableContainer>
         </Box>
@@ -104,7 +126,7 @@ function DatabaseTable(props) {
 
 function TableRow(props) {
     let rowValues = new Array(props.tableHeaders.length).fill(null);
-    rowValues[0] = props.obj.id;
+    rowValues[1] = props.obj.id;
     Object.keys(props.obj.attributes).map((key) => {
         const mutIndex = props.tableHeaders.findIndex((elem) => (elem === key));
         rowValues[mutIndex] = props.obj.attributes[key];
@@ -112,6 +134,16 @@ function TableRow(props) {
 
     return (
         <Tr key={props.idx}>
+            <Td><Checkbox
+                colorScheme={'red'}
+                onChange={(e) => {
+                    if(e.target.checked) {
+                        props.addToDelete(props.obj);
+                    } else {
+                        props.removeFromDelete(props.obj)
+                    }
+
+                }}></Checkbox></Td>
             {
                 rowValues.map((e, idx) => (
                     <Td maxW={'250px'} overflow={'auto'} key={idx}>{e ? (e.id || e.toString()) : "null"}</Td>
@@ -119,5 +151,4 @@ function TableRow(props) {
             }
         </Tr>
     )
-
 }

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/DevDashboard/DevDashboard.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Parse from 'parse/dist/parse.min.js'
-import DevTools from '../../devtools/devtools';
+import DevTools from '../../DevTools/DevTools';
 
 import { Center, Text, Spinner} from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
@@ -11,19 +11,24 @@ Parse.serverURL = 'https://parseapi.back4app.com/';
 export default function DevDashboard() {
     const navigate = useNavigate();
     const [isVisible, setIsVisible] = React.useState(false);
-    const [isLoading, setIsLoading] = React.useState(true);
+    const [databaseSchema, setDatabaseSchema] = React.useState({});
+    console.log("🚀 ~ file: DevDashboard.jsx ~ line 15 ~ DevDashboard ~ databaseSchema", databaseSchema)
 
     React.useEffect(() => {
-        const validatePrivileges = async () => {
+        const onMount = async () => {
             const isAllowed = await DevTools.validateRoot();
             if(isAllowed){
                 setIsVisible(true);
             } else{
                 navigate(-1);
             }
+
+            const schema = await DevTools.getCompleteSchema();
+            setDatabaseSchema(schema);
+
         }
 
-        validatePrivileges();
+        onMount();
     }, []);
 
     if(!isVisible){

--- a/buzzmoon-frontend/buzzmoon-vite/src/devtools/devtools.js
+++ b/buzzmoon-frontend/buzzmoon-vite/src/devtools/devtools.js
@@ -11,4 +11,11 @@ export default class DevTools{
         return response;
     }
 
+    // returns the complete schema of the database
+    static async getCompleteSchema() {
+        const response = await Parse.Cloud.run("getCompleteSchema");
+
+        return response;
+    }
+
 }

--- a/buzzmoon-frontend/buzzmoon-vite/src/devtools/devtools.js
+++ b/buzzmoon-frontend/buzzmoon-vite/src/devtools/devtools.js
@@ -24,4 +24,11 @@ export default class DevTools{
         return classData;
     }
 
+    // deletes a list of objects from the database
+    static async deleteObjList(objList){
+        await Promise.all(objList.map(async (e) => {
+            await Parse.Cloud.run("deleteObject", {id:e.id, cName:e.className});
+        }));
+    }
+
 }

--- a/buzzmoon-frontend/buzzmoon-vite/src/devtools/devtools.js
+++ b/buzzmoon-frontend/buzzmoon-vite/src/devtools/devtools.js
@@ -1,0 +1,14 @@
+import * as Parse from 'parse/dist/parse.min.js'
+
+Parse.initialize('nUrzDufzLEaJ3sjzvcvNHvw1hD46jOt4yEipaWHs', 'juaO5lbdY5jTtDXGpzEr2mGtggC0wf2Es11cEruf');
+Parse.serverURL = 'https://parseapi.back4app.com/';
+
+export default class DevTools{
+
+    // validates that the current user has root privileges
+    static async validateRoot() {
+        const response = await Parse.Cloud.run("validateRoot");
+        return response;
+    }
+
+}

--- a/buzzmoon-frontend/buzzmoon-vite/src/devtools/devtools.js
+++ b/buzzmoon-frontend/buzzmoon-vite/src/devtools/devtools.js
@@ -18,4 +18,10 @@ export default class DevTools{
         return response;
     }
 
+    // returns the complete data of a given class
+    static async getClassData(className){
+        const classData = await Parse.Cloud.run("getClassData", {className});
+        return classData;
+    }
+
 }


### PR DESCRIPTION
We set up a basic developer dashboard on the site to allow us to view and edit the database from a page on the site. The root user can view all of the objects associated with a given class, and select objects to delete. This will speed up the development process by allowing us to clean up test data and out of data database stuff quicker. Everything on the dev dashboard is validated to only allow the root user to view and use it, so there is no security risk that an unauthorized user could access the database.

demo: https://www.screencast.com/t/NKXkfNP5