### PR TITLE
9 add support for best buzzes to leaderboard

### DIFF
--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/BackendActor/backend-actor.js
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/BackendActor/backend-actor.js
@@ -223,4 +223,31 @@ export default class BackendActor {
     return {points, numCorrect, averageCelerity, name};
   }
 
+  // takes an array of gameresults and returns a table of best buzzes for a given game
+  static resultsToBestBuzzesTable(results) {
+    if(results.length === 0){
+      return [];
+    }
+
+    const flatAnswerArray = results.map((e) => (e.answers.map((a) => ({...a, player:(e.name)})))).flat();
+
+    const maxQuestionIndex = Math.max(...flatAnswerArray.map((e) => (e.questionNumber)));
+
+    let response = new Array(maxQuestionIndex).fill(null);
+    for (let i = 0; i < maxQuestionIndex; i++) {
+      const questionAnswers = flatAnswerArray
+                                .filter((e) => (e.questionNumber === i+1))
+                                .filter((e) => (e.points > 0));
+
+      if(questionAnswers.length > 0) {
+        const bestBuzz = questionAnswers.reduce(
+          (acc, curr) =>
+            (acc.celerity > curr.celerity ? acc : curr), questionAnswers[0]);
+        response[i] = bestBuzz;
+      }
+    }
+
+    return response;
+  }
+
 }

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
@@ -113,13 +113,20 @@ function BestBuzzesTable(props) {
         </Tr>
       </Thead>
       <Tbody>
-        {props.table.map((e, idx) => (
-          <Tr key={idx}>
+        {props.table.map((e, idx) => (e ?
+          (<Tr key={idx}>
             <Td>{idx+1}</Td>
             <Td>{e.givenAnswer}</Td>
             <Td>{e.player}</Td>
             <Td isNumeric>{e.points}</Td>
             <Td isNumeric>{formatter.format(e.celerity)}</Td>
+          </Tr>) :
+          <Tr key={idx}>
+            <Td>{idx+1}</Td>
+            <Td>No Answers</Td>
+            <Td></Td>
+            <Td></Td>
+            <Td></Td>
           </Tr>
         ))}
       </Tbody>

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
@@ -9,7 +9,6 @@ export default function Results(props) {
   const {gameID} = useParams();
   const [gameData, setGameData] = React.useState();
   const [results, setResults] = React.useState([]);
-  const [resultsCat, setResultsCat] = React.useState("normal");
 
 
   React.useEffect(() => {
@@ -28,6 +27,7 @@ export default function Results(props) {
   }, []);
 
   const standardTable = BackendActor.resultsToStandardTable(results);
+  const bestBuzzesTable = BackendActor.resultsToBestBuzzesTable(results);
 
   if (! gameData) {
     return (
@@ -54,6 +54,12 @@ export default function Results(props) {
           <TabPanel>
             <StandardTable table={standardTable}/>
           </TabPanel>
+          <TabPanel>
+
+          </TabPanel>
+          <TabPanel>
+            <BestBuzzesTable table={bestBuzzesTable} />
+          </TabPanel>
         </TabPanels>
       </Tabs>
       </Flex>
@@ -64,26 +70,52 @@ export default function Results(props) {
 function StandardTable(props) {
   return (
     <Table w={'100%'}variant={'striped'}>
-          <Thead>
-            <Tr>
-              <Th>Rank</Th>
-              <Th>Name</Th>
-              <Th>Points</Th>
-              <Th># Correct</Th>
-            </Tr>
-          </Thead>
-          <Tbody>
-            {props.table.map((e, idx) => (
-              <Tr key={idx}>
-                <Td><Center>{idx+1}{trophyIcon(idx+1)}</Center></Td>
-                <Td>{e.name}</Td>
-                <Td isNumeric>{e.points}</Td>
-                <Td isNumeric>{e.numCorrect}</Td>
-              </Tr>
-            ))}
-          </Tbody>
-        </Table>
+      <Thead>
+        <Tr>
+          <Th>Rank</Th>
+          <Th>Name</Th>
+          <Th>Points</Th>
+          <Th># Correct</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {props.table.map((e, idx) => (
+          <Tr key={idx}>
+            <Td><Center>{idx+1}{trophyIcon(idx+1)}</Center></Td>
+            <Td>{e.name}</Td>
+            <Td isNumeric>{e.points}</Td>
+            <Td isNumeric>{e.numCorrect}</Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
   )
+}
+
+function BestBuzzesTable(props) {
+  return (
+    <Table w={'100%'}variant={'striped'}>
+      <Thead>
+        <Tr>
+          <Th>Rank</Th>
+          <Th>Name</Th>
+          <Th>Points</Th>
+          <Th># Correct</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {props.table.map((e, idx) => (
+          <Tr key={idx}>
+            <Td><Center>{idx+1}{trophyIcon(idx+1)}</Center></Td>
+            <Td>{e.name}</Td>
+            <Td isNumeric>{e.points}</Td>
+            <Td isNumeric>{e.numCorrect}</Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  )
+
 }
 
 function trophyIcon(rank) {

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
@@ -101,7 +101,6 @@ function StandardTable(props) {
 }
 
 function BestBuzzesTable(props) {
-  console.log("🚀 ~ file: Results.jsx ~ line 96 ~ BestBuzzesTable ~ props", props)
   return (
     <Table w={'100%'}variant={'striped'} maxW={'800px'}>
       <Thead>
@@ -126,7 +125,6 @@ function BestBuzzesTable(props) {
       </Tbody>
     </Table>
   )
-
 }
 
 function trophyIcon(rank) {

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
@@ -2,14 +2,15 @@ import * as React from 'react';
 import { useParams } from 'react-router-dom';
 import BackendActor from '../BackendActor/backend-actor';
 
-import { Spinner, Center, Flex, Heading, Table, Thead, Tbody, Tr, Th, Td, Icon} from '@chakra-ui/react';
+import { Spinner, Center, Flex, Heading, Table, Thead, Tbody, Tr, Th, Td, Icon, TabList, Tabs, Tab, TabPanels, TabPanel} from '@chakra-ui/react';
 import {AiFillTrophy} from 'react-icons/ai'
 
 export default function Results(props) {
   const {gameID} = useParams();
   const [gameData, setGameData] = React.useState();
+  const [results, setResults] = React.useState([]);
   const [resultsCat, setResultsCat] = React.useState("normal");
-  const [table, setTable] = React.useState([]);
+
 
   React.useEffect(() => {
     const updateGameData = async () => {
@@ -20,12 +21,13 @@ export default function Results(props) {
       // here we should validate if the user has played the game, or if they should be kicked from results page
 
       const playerResults = await BackendActor.fetchGameResults(gameID);
-      const table = BackendActor.resultsToStandardTable(playerResults);
-      setTable(table);
+      setResults(playerResults);
     }
 
     updateGameData();
   }, []);
+
+  const standardTable = BackendActor.resultsToStandardTable(results);
 
   if (! gameData) {
     return (
@@ -37,11 +39,31 @@ export default function Results(props) {
 
   return (
     <Center mt={'20'}>
+
       <Flex direction={'column'} align={'center'}>
         <Heading borderBottom={'1px solid black'} mb={'10'}>
         {`${gameData.title}`}
         </Heading>
-        <Table w={'100%'}variant={'striped'}>
+        <Tabs size='md' variant='enclosed' colorScheme={'black'}>
+        <TabList>
+          <Tab>Standard</Tab>
+          <Tab>Head 2 Head</Tab>
+          <Tab>Best Buzzes</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <StandardTable table={standardTable}/>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+      </Flex>
+    </Center>
+  )
+}
+
+function StandardTable(props) {
+  return (
+    <Table w={'100%'}variant={'striped'}>
           <Thead>
             <Tr>
               <Th>Rank</Th>
@@ -51,7 +73,7 @@ export default function Results(props) {
             </Tr>
           </Thead>
           <Tbody>
-            {table.map((e, idx) => (
+            {props.table.map((e, idx) => (
               <Tr key={idx}>
                 <Td><Center>{idx+1}{trophyIcon(idx+1)}</Center></Td>
                 <Td>{e.name}</Td>
@@ -61,8 +83,6 @@ export default function Results(props) {
             ))}
           </Tbody>
         </Table>
-      </Flex>
-    </Center>
   )
 }
 

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
@@ -2,8 +2,16 @@ import * as React from 'react';
 import { useParams } from 'react-router-dom';
 import BackendActor from '../BackendActor/backend-actor';
 
-import { Spinner, Center, Flex, Heading, Table, Thead, Tbody, Tr, Th, Td, Icon, TabList, Tabs, Tab, TabPanels, TabPanel} from '@chakra-ui/react';
+import { Spinner, Center, Flex, Heading, Table, Thead, Tbody, Tr, Th, Td, Icon, TabList, Tabs, Tab, TabPanels, TabPanel, VStack} from '@chakra-ui/react';
 import {AiFillTrophy} from 'react-icons/ai'
+
+
+const formatConfig = {
+  minimumFractionDigits: 3,
+  maximumFractionDigits: 3,
+};
+
+const formatter = new Intl.NumberFormat('en-US', formatConfig);
 
 export default function Results(props) {
   const {gameID} = useParams();
@@ -40,11 +48,11 @@ export default function Results(props) {
   return (
     <Center mt={'20'}>
 
-      <Flex direction={'column'} align={'center'}>
+      <VStack w={{sm:"95vw", md: "75vw", lg:"60vw"}} align={'center'} overflowX={'auto'}>
         <Heading borderBottom={'1px solid black'} mb={'10'}>
         {`${gameData.title}`}
         </Heading>
-        <Tabs size='md' variant='enclosed' colorScheme={'black'}>
+        <Tabs w={{base:"95vw", sm: "95vw", md:"100%"}} size='md' variant='enclosed' colorScheme={'black'}>
         <TabList>
           <Tab>Standard</Tab>
           <Tab>Head 2 Head</Tab>
@@ -62,14 +70,14 @@ export default function Results(props) {
           </TabPanel>
         </TabPanels>
       </Tabs>
-      </Flex>
+      </VStack>
     </Center>
   )
 }
 
 function StandardTable(props) {
   return (
-    <Table w={'100%'}variant={'striped'}>
+    <Table variant={'striped'} maxW={'min(600px, 100%)'}>
       <Thead>
         <Tr>
           <Th>Rank</Th>
@@ -93,23 +101,26 @@ function StandardTable(props) {
 }
 
 function BestBuzzesTable(props) {
+  console.log("🚀 ~ file: Results.jsx ~ line 96 ~ BestBuzzesTable ~ props", props)
   return (
-    <Table w={'100%'}variant={'striped'}>
+    <Table w={'100%'}variant={'striped'} maxW={'800px'}>
       <Thead>
         <Tr>
-          <Th>Rank</Th>
-          <Th>Name</Th>
+          <Th>#</Th>
+          <Th>Answer</Th>
+          <Th>Player</Th>
           <Th>Points</Th>
-          <Th># Correct</Th>
+          <Th>Celerity</Th>
         </Tr>
       </Thead>
       <Tbody>
         {props.table.map((e, idx) => (
           <Tr key={idx}>
-            <Td><Center>{idx+1}{trophyIcon(idx+1)}</Center></Td>
-            <Td>{e.name}</Td>
+            <Td>{idx+1}</Td>
+            <Td>{e.givenAnswer}</Td>
+            <Td>{e.player}</Td>
             <Td isNumeric>{e.points}</Td>
-            <Td isNumeric>{e.numCorrect}</Td>
+            <Td isNumeric>{formatter.format(e.celerity)}</Td>
           </Tr>
         ))}
       </Tbody>


### PR DESCRIPTION
We set up the "best buzzes" page on the leaderboard, which displays the player that got the fastest answer to each question in a given game. This is a desired statistical item by the target demographic of the site. The next step will be to continue fleshing out the results page by adding the "head to head" data. 

Demo: https://www.screencast.com/t/ySCzYoDuvCs