### PR TITLE
10 add support for head to head mode of game

### DIFF
--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/BackendActor/backend-actor.js
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/BackendActor/backend-actor.js
@@ -250,4 +250,55 @@ export default class BackendActor {
     return response;
   }
 
+  static resultsToHeadToHeadTable(results) {
+    let response = []
+    results.map((r) => {
+      let w = 0;
+      let l = 0;
+      let t = 0;
+      let outcomes = [];
+      results.filter((e) => (e.name !== r.name)).map((o) => {
+        let oscore = 0;
+        let rscore = 0;
+        const maxQuestionIndex = Math.max(...(o.answers).map((e) => (e.questionNumber)),
+                                  ...(r.answers).map((o) => (o.questionNumber)));
+        for(let i = 0; i < maxQuestionIndex; i++){
+          let ocel = 0;
+          let rcel = 0;
+          const oans = o.answers.find((e) => (e.questionNumber === i+1));
+          const rans = r.answers.find((e) => (e.questionNumber === i+1));
+          if(oans && oans.points > 0){
+            ocel = oans.celerity;
+          }
+          if(rans && rans.points > 0){
+            rcel = rans.celerity;
+          }
+          if(ocel >= rcel && oans){
+            oscore += oans.points ;
+          }
+          if(rcel >= ocel && rans){
+            rscore += rans.points;
+          }
+
+        }
+
+
+        if(oscore > rscore){
+          l++;
+          outcomes.push({oppName:o.name, res:"loss", score:rscore, oscore});
+        } else if (oscore < rscore) {
+          w++;
+          outcomes.push({oppName:o.name, res:"win", score:rscore, oscore});
+        } else{
+          t++;
+          outcomes.push({oppName:o.name, res:"tie", score:rscore, oscore});
+        }
+      })
+      const games = w+l+t;
+      const score = w + 0.5*t;
+      response.push({name:r.name, w, l, t, percentage:score/games, outcomes});
+    })
+    return response.sort((a,b) => (a.percentage > b.percentage ? -1 : 1));
+  }
+
 }

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
@@ -3,9 +3,12 @@ import { useParams } from 'react-router-dom';
 import BackendActor from '../BackendActor/backend-actor';
 
 import { Spinner, Center, Tooltip, Heading, Table, Thead, Tbody, Tr, Th, Td, Icon,
-     TabList, Tabs, Tab, TabPanels, TabPanel, VStack, Box, HStack, Text} from '@chakra-ui/react';
-import {AiFillTrophy, AiOutlineQuestionCircle} from 'react-icons/ai'
+        TabList, Tabs, Tab, TabPanels, TabPanel, VStack, Box, HStack, Text, Button,
+        Popover, PopoverBody, PopoverContent, PopoverTrigger, PopoverArrow,
+        PopoverHeader, PopoverCloseButton} from '@chakra-ui/react';
+import {AiFillTrophy, AiOutlineQuestionCircle, AiOutlineCheck, AiOutlineClose, AiOutlineDash} from 'react-icons/ai'
 
+import { TiEquals } from "react-icons/ti";
 
 const formatConfig = {
   minimumFractionDigits: 3,
@@ -131,20 +134,60 @@ function StandardTable(props) {
 
 function HeadToHeadTable(props) {
   return (
-    <Table w={'100%'}variant={'striped'} maxW={'600px'}>
+    <Table w={'100%'} variant={'simple'} maxW={'600px'}>
       <Thead>
         <Tr>
           <Th>Player</Th>
           <Th>Record</Th>
           <Th>Win %</Th>
+          <Th></Th>
         </Tr>
       </Thead>
       <Tbody>
         {props.table.map((e, idx) => (
-          <Tr key={idx}>
+          <Tr key={idx} backgroundColor={((1+idx%2)) === 1 ? "gray.100" : "white"}>
             <Td>{trophyIcon(idx+1)} {e.name} </Td>
             <Td>{`${e.w}-${e.l}-${e.t}`}</Td>
             <Td isNumeric>{formatter.format(e.percentage)}</Td>
+            <Td>
+              <Popover >
+                <PopoverTrigger>
+                  <Button colorScheme={'blue'}>Details</Button>
+                </PopoverTrigger>
+                <PopoverContent w={'fit-content'}>
+                  <PopoverArrow />
+                  <PopoverCloseButton />
+                  <PopoverBody>
+                    <Table variant={'unstyled'} key={e.name}>
+                      <Thead>
+                        <Tr bg={'white'}>
+                          <Th></Th>
+                          <Th>Opponent</Th>
+                          <Th>Score</Th>
+                        </Tr>
+                      </Thead>
+                      <Tbody>
+                        {e.outcomes.map((o, idx) => (
+                          <Tr key={Math.random() + e.name + idx + o.oppName}>
+                            <Td>
+                              {o.res === "win" &&
+                                <Icon color={'green'} fontWeight={'2xl'} as={AiOutlineCheck}></Icon>}
+                              {o.res === "loss" &&
+                                <Icon color={'red'} fontWeight={'2xl'} as={AiOutlineClose}></Icon>}
+                              {o.res === "tie" &&
+                                <Icon fontWeight={'2xl'}  as={TiEquals}></Icon>}
+
+                            </Td>
+                            <Td>{o.oppName}</Td>
+                            <Td whiteSpace={'no-wrap'}>{`${o.score}-${o.oscore}`}</Td>
+                          </Tr>
+                        ))}
+                      </Tbody>
+                    </Table>
+                  </PopoverBody>
+                </PopoverContent>
+              </Popover>
+            </Td>
           </Tr>)
         )}
       </Tbody>

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
@@ -36,6 +36,8 @@ export default function Results(props) {
 
   const standardTable = BackendActor.resultsToStandardTable(results);
   const bestBuzzesTable = BackendActor.resultsToBestBuzzesTable(results);
+  const headToHeadTable = BackendActor.resultsToHeadToHeadTable(results);
+  console.log("🚀 ~ file: Results.jsx ~ line 40 ~ Results ~ headToHeadTable", headToHeadTable)
 
   if (! gameData) {
     return (
@@ -63,7 +65,7 @@ export default function Results(props) {
             <StandardTable table={standardTable}/>
           </TabPanel>
           <TabPanel>
-
+            <HeadToHeadTable table={headToHeadTable}/>
           </TabPanel>
           <TabPanel>
             <BestBuzzesTable table={bestBuzzesTable} />
@@ -98,6 +100,29 @@ function StandardTable(props) {
       </Tbody>
     </Table>
   )
+}
+
+function HeadToHeadTable(props) {
+  return (
+    <Table w={'100%'}variant={'striped'} maxW={'600px'}>
+      <Thead>
+        <Tr>
+          <Th>Player</Th>
+          <Th>Record</Th>
+          <Th>Win %</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {props.table.map((e, idx) => (
+          <Tr key={idx}>
+            <Td>{e.name}</Td>
+            <Td>{`${e.w}-${e.l}-${e.t}`}</Td>
+            <Td isNumeric>{formatter.format(e.percentage)}</Td>
+          </Tr>)
+        )}
+      </Tbody>
+    </Table>
+  );
 }
 
 function BestBuzzesTable(props) {

--- a/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
+++ b/buzzmoon-frontend/buzzmoon-vite/src/Components/Results/Results.jsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { useParams } from 'react-router-dom';
 import BackendActor from '../BackendActor/backend-actor';
 
-import { Spinner, Center, Flex, Heading, Table, Thead, Tbody, Tr, Th, Td, Icon, TabList, Tabs, Tab, TabPanels, TabPanel, VStack} from '@chakra-ui/react';
-import {AiFillTrophy} from 'react-icons/ai'
+import { Spinner, Center, Tooltip, Heading, Table, Thead, Tbody, Tr, Th, Td, Icon,
+     TabList, Tabs, Tab, TabPanels, TabPanel, VStack, Box, HStack, Text} from '@chakra-ui/react';
+import {AiFillTrophy, AiOutlineQuestionCircle} from 'react-icons/ai'
 
 
 const formatConfig = {
@@ -37,7 +38,6 @@ export default function Results(props) {
   const standardTable = BackendActor.resultsToStandardTable(results);
   const bestBuzzesTable = BackendActor.resultsToBestBuzzesTable(results);
   const headToHeadTable = BackendActor.resultsToHeadToHeadTable(results);
-  console.log("🚀 ~ file: Results.jsx ~ line 40 ~ Results ~ headToHeadTable", headToHeadTable)
 
   if (! gameData) {
     return (
@@ -56,9 +56,36 @@ export default function Results(props) {
         </Heading>
         <Tabs w={{base:"95vw", sm: "95vw", md:"100%"}} size='md' variant='enclosed' colorScheme={'black'}>
         <TabList>
-          <Tab>Standard</Tab>
-          <Tab>Head 2 Head</Tab>
-          <Tab>Best Buzzes</Tab>
+          <Tab>
+          <HStack align={'start'}>
+            <Text>Standard</Text>
+            <Tooltip hasArrow
+              label='Players are ranked by points scored'
+              bg='gray.300' color='black'>
+              <Box ml={'2'} as={'span'}><Icon as={AiOutlineQuestionCircle}></Icon></Box>
+            </Tooltip>
+          </HStack>
+        </Tab>
+        <Tab>
+          <HStack align={'start'}>
+            <Text>Head to Head</Text>
+            <Tooltip hasArrow
+              label='Players are ranked by the results of simulated games against each other'
+              bg='gray.300' color='black'>
+              <Box ml={'2'} as={'span'}><Icon as={AiOutlineQuestionCircle}></Icon></Box>
+            </Tooltip>
+          </HStack>
+        </Tab>
+        <Tab>
+          <HStack align={'start'}>
+            <Text>Best Buzzes</Text>
+            <Tooltip hasArrow
+              label='View the fastest buzzes for each question'
+              bg='gray.300' color='black'>
+              <Box ml={'2'} as={'span'}><Icon as={AiOutlineQuestionCircle}></Icon></Box>
+            </Tooltip>
+          </HStack>
+        </Tab>
         </TabList>
         <TabPanels>
           <TabPanel>
@@ -91,7 +118,7 @@ function StandardTable(props) {
       <Tbody>
         {props.table.map((e, idx) => (
           <Tr key={idx}>
-            <Td><Center>{idx+1}{trophyIcon(idx+1)}</Center></Td>
+            <Td><Center>{trophyIcon(idx+1)}{idx+1}</Center></Td>
             <Td>{e.name}</Td>
             <Td isNumeric>{e.points}</Td>
             <Td isNumeric>{e.numCorrect}</Td>
@@ -115,7 +142,7 @@ function HeadToHeadTable(props) {
       <Tbody>
         {props.table.map((e, idx) => (
           <Tr key={idx}>
-            <Td>{e.name}</Td>
+            <Td>{trophyIcon(idx+1)} {e.name} </Td>
             <Td>{`${e.w}-${e.l}-${e.t}`}</Td>
             <Td isNumeric>{formatter.format(e.percentage)}</Td>
           </Tr>)


### PR DESCRIPTION
We successfully implemented the "head to head" results screen in the leaderboard, which ranks users based on simulating a game between every user and every other user. We implemented the logic necessary to calculate these results, created the table to display the results, and included "details" popovers that show the specific outcomes of each simulated game. We also added tooltips to each tab of the results screen to better clarify what each result represents. 

Demo: https://www.screencast.com/t/EnoFIxqy2YqH